### PR TITLE
updated dozier 2022 equations

### DIFF
--- a/topocalc/viewf.py
+++ b/topocalc/viewf.py
@@ -4,8 +4,7 @@ from topocalc.gradient import gradient_d8
 from topocalc.horizon import horizon
 
 
-def dozier_2022(angles, dem, spacing, aspect, 
-                cos_slope, sin_slope, tan_slope, svf):
+def dozier_2022(angles, dem, spacing, aspect, slope, svf):
     '''
     Sky view factor as calcualted in Dozier,2022
     
@@ -13,6 +12,10 @@ def dozier_2022(angles, dem, spacing, aspect,
     IEEE Geoscience and Remote Sensing Letters, 19, 1-5.
     
     '''
+    # Compute trig
+    sin_slope = np.sin(slope)
+    cos_slope = np.cos(slope)
+    tan_slope = np.tan(slope)
 
     for angle in angles:
 
@@ -46,8 +49,7 @@ def dozier_2022(angles, dem, spacing, aspect,
     return svf, tcf
 
 
-def dozier_and_frew_1990(angles, dem, spacing, aspect, 
-                         cos_slope, sin_slope, svf):
+def dozier_and_frew_1990(angles, dem, spacing, aspect, slope, svf):
     '''
     Sky view factor as calcualted in Eq 7b Dozier & Frew, 1990:
 
@@ -58,6 +60,10 @@ def dozier_and_frew_1990(angles, dem, spacing, aspect,
 
     
     '''
+
+    # Compute trig
+    sin_slope = np.sin(slope)
+    cos_slope = np.cos(slope)
 
     # Loop through n_angles
     for angle in angles:
@@ -138,9 +144,6 @@ def viewf(dem, spacing, nangles=72, method='dozier_2022', sin_slope=None, aspect
     if sin_slope is None:
         slope, aspect = gradient_d8(
             dem, dx=spacing, dy=spacing, aspect_rad=True)
-        sin_slope = np.sin(slope)
-        cos_slope = np.cos(slope)
-        tan_slope = np.tan(slope)
 
     # -180 is North
     angles = np.linspace(-180, 180, num=nangles, endpoint=False)
@@ -151,11 +154,11 @@ def viewf(dem, spacing, nangles=72, method='dozier_2022', sin_slope=None, aspect
     # perform the integral based on which method
     if method == 'dozier_and_frew_1990':
         svf,tcf = dozier_and_frew_1990(angles, dem, spacing, 
-                                       aspect,cos_slope, sin_slope, svf)
+                                       aspect, slope, svf)
 
     elif method == 'dozier_2022':
         svf,tcf = dozier_2022(angles, dem, spacing, 
-                              aspect,cos_slope, sin_slope, tan_slope, svf)
+                              aspect, slope, svf)
 
     else:
         raise Exception("Unknown sky view factor method given")

--- a/topocalc/viewf.py
+++ b/topocalc/viewf.py
@@ -49,7 +49,13 @@ def dozier_2022(angles, dem, spacing, aspect,
 def dozier_and_frew_1990(angles, dem, spacing, aspect, 
                          cos_slope, sin_slope, svf):
     '''
-    Sky view factor as calcualted in Dozier & Frew, 1990.
+    Sky view factor as calcualted in Eq 7b Dozier & Frew, 1990:
+
+    .. math::
+        V_d \approx \frac{1}{2\pi} \int_{0}^{2\pi}\left [ cos(S) sin^2{H_\phi} 
+        + sin(S)cos(\phi-A) \times \left ( H_\phi - sin(H_\phi) cos(H_\phi)
+        \right )\right ] d\phi
+
     
     '''
 
@@ -91,7 +97,7 @@ def viewf(dem, spacing, nangles=72, method='dozier_2022', sin_slope=None, aspect
     IEEE Geoscience and Remote Sensing Letters, 19, 1-5.
 
 
-    Alternatively, it can be ran using equation 7b from Dozier and Frew 1990
+    Alternatively, it can be ran using equation 7b from Dozier and Frew 1990.
 
 
     terrain configuration factor (tvf) is defined as:

--- a/topocalc/viewf.py
+++ b/topocalc/viewf.py
@@ -3,46 +3,27 @@ import numpy as np
 from topocalc.gradient import gradient_d8
 from topocalc.horizon import horizon
 
-
-def d2r(a):
-    """Angle to radians
-
-    Arguments:
-        a {float} -- angle in degrees
-
-    Returns:
-        v {float} -- angle in radians
+def viewf(dem, spacing, nangles=72, method='dozier_2022', sin_slope=None, aspect=None):
     """
-    v = a * np.pi / 180
-    v = round(v, 6)  # just for testing at the moment
-    return v
+    Calculate the sky view factor of a dem, as written in Dozier,2022,
+
+    Dozier, J. (2022). Revisiting topographic horizons in the era of big data and parallel Computing. 
+    IEEE Geoscience and Remote Sensing Letters, 19, 1-5.
 
 
-def viewf(dem, spacing, nangles=72, sin_slope=None, aspect=None):
-    """
-    Calculate the sky view factor of a dem.
+    Alternatively, it can be ran using equation 7b from Dozier and Frew 1990
 
-    The sky view factor from equation 7b from Dozier and Frew 1990
-
-    .. math::
-        V_d \approx \frac{1}{2\pi} \int_{0}^{2\pi}\left [ cos(S) sin^2{H_\phi} 
-        + sin(S)cos(\phi-A) \times \left ( H_\phi - sin(H_\phi) cos(H_\phi)
-        \right )\right ] d\phi
 
     terrain configuration factor (tvf) is defined as:
         (1 + cos(slope))/2 - sky view factor
 
-    Based on the paper Dozier and Frew, 1990 and modified from
-    the Image Processing Workbench code base (Frew, 1990). The
-    Python version of sky view factor will be an almost exact
-    replication of the IPW command `viewf` minus rounding errors
-    from type and linear quantization.
 
     Args:
         dem: numpy array for the DEM
         spacing: grid spacing of the DEM
         nangles: number of angles to estimate the horizon, defaults
                 to 72 angles
+        method: Either 'dozier_2022' or 'dozier_and_frew_1990'
         sin_slope: optional, will calculate if not provided
                     sin(slope) with range from 0 to 1
         aspect: optional, will calculate if not provided
@@ -61,7 +42,7 @@ def viewf(dem, spacing, nangles=72, sin_slope=None, aspect=None):
 
     if nangles < 16:
         raise ValueError('viewf number of angles should be 16 or greater')
-
+    
     if sin_slope is not None:
         if np.max(sin_slope) > 1:
             raise ValueError('slope must be sin(slope) with range from 0 to 1')
@@ -72,37 +53,69 @@ def viewf(dem, spacing, nangles=72, sin_slope=None, aspect=None):
         slope, aspect = gradient_d8(
             dem, dx=spacing, dy=spacing, aspect_rad=True)
         sin_slope = np.sin(slope)
+        cos_slope = np.cos(slope)
+        tan_slope = np.tan(slope)
 
     # -180 is North
     angles = np.linspace(-180, 180, num=nangles, endpoint=False)
 
-    # perform the integral
-    cos_slope = np.sqrt((1 - sin_slope) * (1 + sin_slope))
+    # Create zeros like array similar to DEM
     svf = np.zeros_like(sin_slope)
-    for angle in angles:
 
-        # horizon angles
-        hcos = horizon(angle, dem, spacing)
-        azimuth = d2r(angle)
+    # perform the integral
+    # If 1990 is in the method, use Dozier Frew 1990 method.
+    if '90' in method:
+        for angle in angles:
 
-        # sin^2(H)
-        sin_squared = (1 - hcos) * (1 + hcos)
+            # horizon angles
+            hcos = horizon(angle, dem, spacing)
+            azimuth = np.radians(angle)
 
-        # H - sin(H)cos(H)
-        h_mult = np.arccos(hcos) - np.sqrt(sin_squared) * hcos
+            # sin^2(H)
+            sin_squared = (1 - hcos) * (1 + hcos)
 
-        # cosines of difference between horizon aspect and slope aspect
-        cos_aspect = np.cos(azimuth - aspect)
+            # H - sin(H)cos(H)
+            h_mult = np.arccos(hcos) - np.sqrt(sin_squared) * hcos
 
-        # integral in equation 7b
-        intgrnd = cos_slope * sin_squared + \
-            sin_slope * cos_aspect * h_mult
+            # cosines of difference between horizon aspect and slope aspect
+            cos_aspect = np.cos(azimuth - aspect)
 
-        ind = intgrnd > 0
-        svf[ind] = svf[ind] + intgrnd[ind]
+            # integral in equation 7b
+            intgrnd = cos_slope * sin_squared + sin_slope * cos_aspect * h_mult
 
+            ind = intgrnd > 0
+            svf[ind] = svf[ind] + intgrnd[ind]
+
+
+    else: # use the updated 2022 method (Default)
+        for angle in angles:
+
+            # horizon angles
+            hcos = horizon(angle, dem, spacing)
+            azimuth = np.radians(angle)
+
+            # H
+            h = np.arccos(hcos)
+
+            # cosines of difference between Slope aspect and horizon azimuth
+            cos_aspect = np.cos(aspect - azimuth)
+
+            # check for slope being obscured
+            # EQ 3 in Dozier et al. 2022
+            #     H(t) = min(H(t), acos(sqrt(1-1./(1+tand(slopeDegrees)^2*cos(azmRadian(t)-aspectRadian).^2))));
+            t = cos_aspect<0
+            h[t] = np.fmin(h[t],np.arccos(np.sqrt(1 - 1/(1 + cos_aspect[t]**2 * tan_slope[t]**2))))
+
+            # integral in Dozier 2022
+            # qIntegrand = (cosd(slopeDegrees)*sin(H).^2 + sind(slopeDegrees)*cos(aspectRadian-azmRadian).*(H-cos(H).*sin(H)))/2
+            intgrnd = (cos_slope * np.sin(h)**2 + sin_slope*cos_aspect * (h - np.sin(h)*np.cos(h)))
+
+            ind = intgrnd > 0
+            svf[ind] = svf[ind] + intgrnd[ind]
+    
+
+    # Compute final arrays
     svf = svf / len(angles)
-
     tcf = (1 + cos_slope)/2 - svf
 
     return svf, tcf


### PR DESCRIPTION
These equations are more accurate than the 1990 method, as they also account for the slope obscuring the horizon. This change as I have typed up here should still work nicely with this current branch of parallelizing the code. 

